### PR TITLE
Filter transit data for buses and trams

### DIFF
--- a/traffic-prediction-app/frontend/src/components/BestRoute.js
+++ b/traffic-prediction-app/frontend/src/components/BestRoute.js
@@ -33,7 +33,7 @@ const center = { lat: 20.5937, lng: 78.9629 };
 
 const travelModes = [
   { id: 'DRIVING', icon: '🚗', label: 'Drive' },
-  { id: 'TRANSIT', icon: '🚌', label: 'Bus' },
+  { id: 'TRANSIT', icon: '🚌', label: 'Bus/Train' },
   { id: 'WALKING', icon: '🚶', label: 'Walk' },
   { id: 'BICYCLING', icon: '🚲', label: 'Bike' }
 ];

--- a/traffic-prediction-app/frontend/src/components/MapContainer.js
+++ b/traffic-prediction-app/frontend/src/components/MapContainer.js
@@ -55,6 +55,7 @@ const MapContainer = ({
             destination: selectedDestination,
             origin: selectedSource,
             travelMode: selectedMode,
+            transitOptions: selectedMode === 'TRANSIT' ? { modes: ['BUS', 'TRAIN'] } : undefined,
             provideRouteAlternatives: true,
             optimizeWaypoints: true,
             waypoints: waypoints,
@@ -78,7 +79,8 @@ const MapContainer = ({
                   request: {
                     destination: selectedDestination,
                     origin: selectedSource,
-                    travelMode: selectedMode
+                    travelMode: selectedMode,
+                    transitOptions: selectedMode === 'TRANSIT' ? { modes: ['BUS', 'TRAIN'] } : undefined
                   }
                 },
                 routeIndex: 0,


### PR DESCRIPTION
Filter transit data cards to show only buses and trains by adding `transitOptions` to Google Directions API requests.

---
<a href="https://cursor.com/background-agent?bcId=bc-65d0b505-a7b9-4846-9af0-49cc0c830f45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-65d0b505-a7b9-4846-9af0-49cc0c830f45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

